### PR TITLE
Structlog event as context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "structlog-sentry"
-version = "1.4.0"
+version = "1.4.1-dev"
 description = "Sentry integration for structlog"
 authors = ["Kiwi.com platform <platform@kiwi.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from setuptools import setup
 
-version = "1.4.1-dev"
+version = "1.4.1"
 
 # read the contents of your README file
 
@@ -15,7 +15,7 @@ setup(
     description="Sentry integration for structlog",
     author="Kiwi.com platform",
     author_email="platform@kiwi.com",
-    packages=['structlog_sentry'],
+    packages=["structlog_sentry"],
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from pathlib import Path
+from setuptools import setup
+
+version = "1.4.1-dev"
+
+# read the contents of your README file
+
+long_description = (Path(__file__).parent / "README.md").read_text()
+
+setup(
+    name="structlog-sentry",
+    version="1.4.1",
+    description="Sentry integration for structlog",
+    author="Kiwi.com platform",
+    author_email="platform@kiwi.com",
+    packages=['structlog_sentry'],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    license="MIT",
+)

--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from typing import List, Optional, Tuple, Union, Set, Iterable
 
-from sentry_sdk import capture_event
+from sentry_sdk import push_scope, capture_event
 from sentry_sdk.integrations.logging import ignore_logger as logging_int_ignore_logger
 from sentry_sdk.utils import event_from_exception
 
@@ -17,27 +17,33 @@ class SentryProcessor:
         self,
         level: int = logging.WARNING,
         active: bool = True,
-        as_extra: bool = True,
+        as_extra: bool = False,
+        as_context: bool = True,
         tag_keys: Union[List[str], str] = None,
         ignore_loggers: Optional[Iterable[str]] = None,
+        ignore_keys: Optional[Iterable[str]] = None,
     ) -> None:
         """
         :param level: events of this or higher levels will be reported to Sentry.
         :param active: a flag to make this processor enabled/disabled.
-        :param as_extra: send `event_dict` as extra info to Sentry.
+        :param as_extra: send `event_dict` as extra info to Sentry. It's limited.
+        :param as_context: send `event_dict` as context data. Not limited.
         :param tag_keys: a list of keys. If any if these keys appear in `event_dict`,
             the key and its corresponding value in `event_dict` will be used as Sentry
             event tags. use `"__all__"` to report all key/value pairs of event as tags.
         :param ignore_loggers: a list of logger names to ignore any events from.
+        :param ignore_keys: a list of keys to ignore from the original event dictionary, if they exist.
         """
         self.level = level
         self.active = active
         self.tag_keys = tag_keys
         self._as_extra = as_extra
+        self._as_context = as_context
         self._original_event_dict = None
         self._ignored_loggers: Set[str] = set()
         if ignore_loggers is not None:
             self._ignored_loggers.update(set(ignore_loggers))
+        self._ignore_keys = ignore_keys or []
 
     @staticmethod
     def _get_logger_name(logger, event_dict: dict) -> Optional[str]:
@@ -60,7 +66,7 @@ class SentryProcessor:
 
         return logger_name
 
-    def _get_event_and_hint(self, event_dict: dict) -> Tuple[dict, Optional[str]]:
+    def _get_event_context_and_hint(self, event_dict: dict) -> Tuple[dict, dict, Optional[str]]:
         """Create a sentry event and hint from structlog `event_dict` and sys.exc_info.
 
         :param event_dict: structlog event_dict
@@ -76,13 +82,19 @@ class SentryProcessor:
         else:
             event, hint = {}, None
 
+        context = {}
+
         event["message"] = event_dict.get("event")
         event["level"] = event_dict.get("level")
         if "logger" in event_dict:
             event["logger"] = event_dict["logger"]
 
+        if self._as_context:
+            context = self._original_event_dict.copy()
+
         if self._as_extra:
             event["extra"] = self._original_event_dict.copy()
+
         if self.tag_keys == "__all__":
             event["tags"] = self._original_event_dict.copy()
         elif isinstance(self.tag_keys, list):
@@ -90,15 +102,22 @@ class SentryProcessor:
                 key: event_dict[key] for key in self.tag_keys if key in event_dict
             }
 
-        return event, hint
+        return event, context, hint
 
     def _log(self, event_dict: dict) -> str:
         """Send an event to Sentry and return sentry event id.
 
         :param event_dict: structlog event_dict
         """
-        event, hint = self._get_event_and_hint(event_dict)
-        return capture_event(event, hint=hint)
+        event, context, hint = self._get_event_context_and_hint(event_dict)
+        if context:
+            with push_scope() as scope:
+                scope.set_context("Log event data", context)
+                event_id = capture_event(event, hint=hint)
+        else:
+            event_id = capture_event(event, hint=hint)
+
+        return event_id
 
     def __call__(self, logger, method, event_dict) -> dict:
         """A middleware to process structlog `event_dict` and send it to Sentry."""
@@ -107,7 +126,7 @@ class SentryProcessor:
             event_dict["sentry"] = "ignored"
             return event_dict
 
-        self._original_event_dict = event_dict.copy()
+        self._original_event_dict = {k: v for k, v in event_dict.items() if k not in self._ignore_keys}
         sentry_skip = event_dict.pop("sentry_skip", False)
         do_log = getattr(logging, event_dict["level"].upper()) >= self.level
 

--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -97,10 +97,10 @@ class SentryProcessor:
             event["logger"] = event_dict["logger"]
 
         if self._mode == Mode.context:
-            context = self._original_event_dict.copy()
+            context = self._filtered_event_dict.copy()
 
         elif self._mode == Mode.extra:
-            event["extra"] = self._original_event_dict.copy()
+            event["extra"] = self._filtered_event_dict.copy()
 
         if self.tag_keys == "__all__":
             event["tags"] = self._original_event_dict.copy()
@@ -133,7 +133,8 @@ class SentryProcessor:
             event_dict["sentry"] = "ignored"
             return event_dict
 
-        self._original_event_dict = {k: v for k, v in event_dict.items() if k not in self._ignore_keys}
+        self._original_event_dict = event_dict
+        self._filtered_event_dict = {k: v for k, v in event_dict.items() if k not in self._ignore_keys}
         sentry_skip = event_dict.pop("sentry_skip", False)
         do_log = getattr(logging, event_dict["level"].upper()) >= self.level
 

--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import logging
 import sys
 from typing import List, Optional, Tuple, Union, Set, Iterable
@@ -5,6 +6,11 @@ from typing import List, Optional, Tuple, Union, Set, Iterable
 from sentry_sdk import push_scope, capture_event
 from sentry_sdk.integrations.logging import ignore_logger as logging_int_ignore_logger
 from sentry_sdk.utils import event_from_exception
+
+
+class Mode(Enum):
+    context = "context"
+    extra = "extra"
 
 
 class SentryProcessor:
@@ -17,7 +23,7 @@ class SentryProcessor:
         self,
         level: int = logging.WARNING,
         active: bool = True,
-        mode: str = "context"
+        mode: Mode = Mode.context,
         tag_keys: Union[List[str], str] = None,
         ignore_loggers: Optional[Iterable[str]] = None,
         ignore_keys: Optional[Iterable[str]] = None,
@@ -27,7 +33,7 @@ class SentryProcessor:
         :param active: a flag to make this processor enabled/disabled.
 
         :param mode: determines the way to send the `event_dict` to sentry.
-            Valid values are "context" (current default) or "extra"
+            Valid values are `Mode.context' (current default) or `Mode.extra`
             (legacy default, deprecated and limited).
             Otherwhise, only the message will be sent.
         :param tag_keys: a list of keys. If any if these keys appear in `event_dict`,
@@ -90,10 +96,10 @@ class SentryProcessor:
         if "logger" in event_dict:
             event["logger"] = event_dict["logger"]
 
-        if self._mode == "context":
+        if self._mode == Mode.context:
             context = self._original_event_dict.copy()
 
-        elif self._mode == "extra":
+        elif self._mode == Mode.extra:
             event["extra"] = self._original_event_dict.copy()
 
         if self.tag_keys == "__all__":

--- a/structlog_sentry/__init__.py
+++ b/structlog_sentry/__init__.py
@@ -23,7 +23,7 @@ class SentryProcessor:
         self,
         level: int = logging.WARNING,
         active: bool = True,
-        mode: Mode = Mode.context,
+        mode: Optional[Mode] = Mode.context,
         tag_keys: Union[List[str], str] = None,
         ignore_loggers: Optional[Iterable[str]] = None,
         ignore_keys: Optional[Iterable[str]] = None,


### PR DESCRIPTION
with this PR we send the structlog event's data as a "contexts", which is the current recommended way to enrich sentry's events. (the legacy behaviour, based on "extra" values, is still possible, although it support much less data)

 https://docs.sentry.io/platforms/python/enriching-events/context/.  
In addition, it's possible to ignore some keys of the original event (for instance, to ignore information we already have like the logger name, timestamp, etc.) 

![image](https://user-images.githubusercontent.com/2355719/137413550-348c1517-365b-4df0-8be8-3fbffea8b21b.png)

See a very verbose example 

https://sentry.io/organizations/test-martin/issues/2720293394/?query=is%3Aunresolved

created with 
```python
import structlog
import faker

slogger = structlog.get_logger()

def sentry_test():
    f = faker.Faker()

    event = {}
    for k in dir(f):
        if k.startswith('__'):
            continue
        try:
            value = getattr(f, k)()
            event[k] = value
        except Exception:
            pass

    slogger.warning(f"A long log", **event)
```

PS: after we agreed and merge this pr to our fork, we could open a new one to the upstream repo. 